### PR TITLE
Implement FalkorDB schema initialization and indexes

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,7 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Literal
 
+
 class Settings(BaseSettings):
     app_name: str = "case-shift-backend"
     environment: Literal["development", "production", "testing"] = "development"
@@ -9,6 +10,7 @@ class Settings(BaseSettings):
     # Optional URL configurations with defaults
     redis_url: str = "redis://localhost:6379/0"
     falkordb_url: str = "redis://localhost:6379/0"
+    falkordb_graph_name: str = "case_shift"
     s3_endpoint_url: str = "http://localhost:4566"
     s3_bucket_name: str = "case-shift-artifacts"
 

--- a/backend/app/db/schema.py
+++ b/backend/app/db/schema.py
@@ -3,23 +3,31 @@ from falkordb import FalkorDB
 
 logger = logging.getLogger(__name__)
 
+
 def init_schema(client: FalkorDB, graph_name: str = "case_shift"):
     """
     Initializes the FalkorDB schema for Tier 1 MVP.
-    Creates necessary indexes for nodes to ensure fast lookups by durable IDs.
+    Creates indexes needed for durable-ID lookup and core Tier 1 retrieval paths.
     """
     logger.info(f"Initializing schema for graph: {graph_name}")
     graph = client.select_graph(graph_name)
 
-    # Tier 1 Node Labels and their durable IDs that need indexes
+    # Required Tier 1 indexes for durable IDs and common retrieval paths.
     indexes = [
         ("Case", "case_id"),
         ("DocketEntry", "entry_id"),
+        ("DocketEntry", "case_id"),
+        ("DocketEntry", "filed_at"),
         ("Document", "doc_id"),
+        ("Document", "case_id"),
+        ("Document", "entry_id"),
+        ("Document", "filed_at"),
         ("Chunk", "chunk_id"),
-        ("Party", "party_id"),     # For Party nodes
-        ("Judge", "judge_id"),     # For Judge nodes
-        ("EventType", "event_type_id"), # For EventType nodes
+        ("Chunk", "doc_id"),
+        ("Chunk", "case_id"),
+        ("Party", "party_id"),
+        ("Judge", "judge_id"),
+        ("EventType", "event_type_id"),
     ]
 
     failures = []
@@ -30,7 +38,6 @@ def init_schema(client: FalkorDB, graph_name: str = "case_shift"):
             graph.query(query)
             logger.info(f"Created index on {label}({property_name})")
         except Exception as e:
-            # FalkorDB will raise an error if index already exists. We can safely ignore it.
             if "already exists" in str(e).lower() or "index already exists" in str(e).lower():
                 logger.debug(f"Index on {label}({property_name}) already exists.")
             else:

--- a/backend/app/db/schema.py
+++ b/backend/app/db/schema.py
@@ -22,6 +22,8 @@ def init_schema(client: FalkorDB, graph_name: str = "case_shift"):
         ("EventType", "event_type_id"), # For EventType nodes
     ]
 
+    failures = []
+
     for label, property_name in indexes:
         try:
             query = f"CREATE INDEX FOR (n:{label}) ON (n.{property_name})"
@@ -33,5 +35,9 @@ def init_schema(client: FalkorDB, graph_name: str = "case_shift"):
                 logger.debug(f"Index on {label}({property_name}) already exists.")
             else:
                 logger.warning(f"Error creating index on {label}({property_name}): {e}")
+                failures.append(e)
+
+    if failures:
+        raise RuntimeError(f"Failed to create {len(failures)} index(es). First error: {failures[0]}")
 
     logger.info("Schema initialization complete.")

--- a/backend/app/db/schema.py
+++ b/backend/app/db/schema.py
@@ -1,0 +1,37 @@
+import logging
+from falkordb import FalkorDB
+
+logger = logging.getLogger(__name__)
+
+def init_schema(client: FalkorDB, graph_name: str = "case_shift"):
+    """
+    Initializes the FalkorDB schema for Tier 1 MVP.
+    Creates necessary indexes for nodes to ensure fast lookups by durable IDs.
+    """
+    logger.info(f"Initializing schema for graph: {graph_name}")
+    graph = client.select_graph(graph_name)
+
+    # Tier 1 Node Labels and their durable IDs that need indexes
+    indexes = [
+        ("Case", "case_id"),
+        ("DocketEntry", "entry_id"),
+        ("Document", "doc_id"),
+        ("Chunk", "chunk_id"),
+        ("Party", "party_id"),     # For Party nodes
+        ("Judge", "judge_id"),     # For Judge nodes
+        ("EventType", "event_type_id"), # For EventType nodes
+    ]
+
+    for label, property_name in indexes:
+        try:
+            query = f"CREATE INDEX FOR (n:{label}) ON (n.{property_name})"
+            graph.query(query)
+            logger.info(f"Created index on {label}({property_name})")
+        except Exception as e:
+            # FalkorDB will raise an error if index already exists. We can safely ignore it.
+            if "already exists" in str(e).lower() or "index already exists" in str(e).lower():
+                logger.debug(f"Index on {label}({property_name}) already exists.")
+            else:
+                logger.warning(f"Error creating index on {label}({property_name}): {e}")
+
+    logger.info("Schema initialization complete.")

--- a/backend/app/scripts/init_db.py
+++ b/backend/app/scripts/init_db.py
@@ -1,0 +1,25 @@
+import logging
+from falkordb import FalkorDB
+from app.core.config import settings
+from app.db.schema import init_schema
+
+# Configure basic logging for the script
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def main():
+    logger.info(f"Connecting to FalkorDB at {settings.falkordb_url}")
+
+    try:
+        # FalkorDB.from_url typically parses redis:// URLs
+        # In the python falkordb package, the typical initialization is:
+        # db = FalkorDB(host='...', port=...)
+        # We can use from_url since falkordb wraps redis
+        client = FalkorDB.from_url(settings.falkordb_url)
+        init_schema(client)
+        logger.info("Successfully initialized FalkorDB schema.")
+    except Exception as e:
+        logger.error(f"Failed to initialize schema: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/scripts/init_db.py
+++ b/backend/app/scripts/init_db.py
@@ -1,6 +1,9 @@
 import logging
 import sys
+from urllib.parse import urlsplit
+
 from falkordb import FalkorDB
+
 from app.core.config import settings
 from app.db.schema import init_schema
 
@@ -8,20 +11,30 @@ from app.db.schema import init_schema
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def _redact_url(url: str) -> str:
+    parts = urlsplit(url)
+    host = parts.hostname or "unknown-host"
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return f"{parts.scheme}://{host}{parts.path}"
+
+
 def main():
-    logger.info(f"Connecting to FalkorDB at {settings.falkordb_url}")
+    logger.info(
+        "Connecting to FalkorDB at %s for graph %s",
+        _redact_url(settings.falkordb_url),
+        settings.falkordb_graph_name,
+    )
 
     try:
-        # FalkorDB.from_url typically parses redis:// URLs
-        # In the python falkordb package, the typical initialization is:
-        # db = FalkorDB(host='...', port=...)
-        # We can use from_url since falkordb wraps redis
         client = FalkorDB.from_url(settings.falkordb_url)
-        init_schema(client)
+        init_schema(client, settings.falkordb_graph_name)
         logger.info("Successfully initialized FalkorDB schema.")
     except Exception:
         logger.exception("Failed to initialize schema")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/backend/app/scripts/init_db.py
+++ b/backend/app/scripts/init_db.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from falkordb import FalkorDB
 from app.core.config import settings
 from app.db.schema import init_schema
@@ -18,8 +19,9 @@ def main():
         client = FalkorDB.from_url(settings.falkordb_url)
         init_schema(client)
         logger.info("Successfully initialized FalkorDB schema.")
-    except Exception as e:
-        logger.error(f"Failed to initialize schema: {e}")
+    except Exception:
+        logger.exception("Failed to initialize schema")
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "falkordb>=1.6.0",
     "fastapi>=0.136.1",
     "pydantic>=2.13.3",
     "pydantic-settings>=2.14.0",

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,5 +1,6 @@
 from app.core.config import Settings
 
+
 def test_settings_default_values():
     settings = Settings()
     assert settings.app_name == "case-shift-backend"
@@ -7,5 +8,6 @@ def test_settings_default_values():
     assert settings.debug is True
     assert settings.redis_url == "redis://localhost:6379/0"
     assert settings.falkordb_url == "redis://localhost:6379/0"
+    assert settings.falkordb_graph_name == "case_shift"
     assert settings.s3_endpoint_url == "http://localhost:4566"
     assert settings.s3_bucket_name == "case-shift-artifacts"

--- a/backend/tests/test_init_db.py
+++ b/backend/tests/test_init_db.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock, patch
+
+from app.scripts.init_db import _redact_url, main
+
+
+def test_redact_url_removes_credentials():
+    redacted = _redact_url("redis://user:secret@example.com:6379/0")
+    assert redacted == "redis://example.com:6379/0"
+
+
+@patch("app.scripts.init_db.init_schema")
+@patch("app.scripts.init_db.FalkorDB")
+def test_main_passes_configured_graph_name(mock_falkordb, mock_init_schema):
+    mock_client = MagicMock()
+    mock_falkordb.from_url.return_value = mock_client
+
+    with patch("app.scripts.init_db.settings") as mock_settings:
+        mock_settings.falkordb_url = "redis://localhost:6379/0"
+        mock_settings.falkordb_graph_name = "custom_graph"
+        main()
+
+    mock_falkordb.from_url.assert_called_once_with("redis://localhost:6379/0")
+    mock_init_schema.assert_called_once_with(mock_client, "custom_graph")

--- a/backend/tests/test_schema.py
+++ b/backend/tests/test_schema.py
@@ -1,45 +1,48 @@
 from unittest.mock import MagicMock
+
+import pytest
+
 from app.db.schema import init_schema
 
+
 def test_init_schema_creates_indexes():
-    # Arrange
     mock_client = MagicMock()
     mock_graph = MagicMock()
     mock_client.select_graph.return_value = mock_graph
 
-    # Act
     init_schema(mock_client, "test_graph")
 
-    # Assert
     mock_client.select_graph.assert_called_once_with("test_graph")
 
-    # Check that query was called for all expected indexes
     expected_calls = [
         "CREATE INDEX FOR (n:Case) ON (n.case_id)",
         "CREATE INDEX FOR (n:DocketEntry) ON (n.entry_id)",
+        "CREATE INDEX FOR (n:DocketEntry) ON (n.case_id)",
+        "CREATE INDEX FOR (n:DocketEntry) ON (n.filed_at)",
         "CREATE INDEX FOR (n:Document) ON (n.doc_id)",
+        "CREATE INDEX FOR (n:Document) ON (n.case_id)",
+        "CREATE INDEX FOR (n:Document) ON (n.entry_id)",
+        "CREATE INDEX FOR (n:Document) ON (n.filed_at)",
         "CREATE INDEX FOR (n:Chunk) ON (n.chunk_id)",
+        "CREATE INDEX FOR (n:Chunk) ON (n.doc_id)",
+        "CREATE INDEX FOR (n:Chunk) ON (n.case_id)",
         "CREATE INDEX FOR (n:Party) ON (n.party_id)",
         "CREATE INDEX FOR (n:Judge) ON (n.judge_id)",
         "CREATE INDEX FOR (n:EventType) ON (n.event_type_id)",
     ]
 
-    # We should have one query per index
     assert mock_graph.query.call_count == len(expected_calls)
-
-    # Extract the queries passed to the mock
     actual_calls = [call.args[0] for call in mock_graph.query.call_args_list]
 
     for expected in expected_calls:
         assert expected in actual_calls
 
+
 def test_init_schema_handles_existing_indexes():
-    # Arrange
     mock_client = MagicMock()
     mock_graph = MagicMock()
     mock_client.select_graph.return_value = mock_graph
 
-    # Simulate the first index already existing
     def side_effect(*args, **kwargs):
         if "Case" in args[0]:
             raise Exception("Index already exists")
@@ -47,22 +50,16 @@ def test_init_schema_handles_existing_indexes():
 
     mock_graph.query.side_effect = side_effect
 
-    # Act
     init_schema(mock_client, "test_graph")
 
-    # Assert
-    # The function should swallow the exception and continue with the rest of the queries
-    assert mock_graph.query.call_count == 7 # 7 indexes total
+    assert mock_graph.query.call_count == 14
+
 
 def test_init_schema_raises_on_unexpected_errors():
-    import pytest
-
-    # Arrange
     mock_client = MagicMock()
     mock_graph = MagicMock()
     mock_client.select_graph.return_value = mock_graph
 
-    # Simulate an unexpected error
     def side_effect(*args, **kwargs):
         if "Case" in args[0]:
             raise Exception("Connection lost")
@@ -70,11 +67,9 @@ def test_init_schema_raises_on_unexpected_errors():
 
     mock_graph.query.side_effect = side_effect
 
-    # Act & Assert
     with pytest.raises(RuntimeError) as exc_info:
         init_schema(mock_client, "test_graph")
 
     assert "Failed to create 1 index(es)" in str(exc_info.value)
     assert "Connection lost" in str(exc_info.value)
-    # It should still attempt to create other indexes despite the first failure
-    assert mock_graph.query.call_count == 7
+    assert mock_graph.query.call_count == 14

--- a/backend/tests/test_schema.py
+++ b/backend/tests/test_schema.py
@@ -53,3 +53,28 @@ def test_init_schema_handles_existing_indexes():
     # Assert
     # The function should swallow the exception and continue with the rest of the queries
     assert mock_graph.query.call_count == 7 # 7 indexes total
+
+def test_init_schema_raises_on_unexpected_errors():
+    import pytest
+
+    # Arrange
+    mock_client = MagicMock()
+    mock_graph = MagicMock()
+    mock_client.select_graph.return_value = mock_graph
+
+    # Simulate an unexpected error
+    def side_effect(*args, **kwargs):
+        if "Case" in args[0]:
+            raise Exception("Connection lost")
+        return MagicMock()
+
+    mock_graph.query.side_effect = side_effect
+
+    # Act & Assert
+    with pytest.raises(RuntimeError) as exc_info:
+        init_schema(mock_client, "test_graph")
+
+    assert "Failed to create 1 index(es)" in str(exc_info.value)
+    assert "Connection lost" in str(exc_info.value)
+    # It should still attempt to create other indexes despite the first failure
+    assert mock_graph.query.call_count == 7

--- a/backend/tests/test_schema.py
+++ b/backend/tests/test_schema.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+from app.db.schema import init_schema
+
+def test_init_schema_creates_indexes():
+    # Arrange
+    mock_client = MagicMock()
+    mock_graph = MagicMock()
+    mock_client.select_graph.return_value = mock_graph
+
+    # Act
+    init_schema(mock_client, "test_graph")
+
+    # Assert
+    mock_client.select_graph.assert_called_once_with("test_graph")
+
+    # Check that query was called for all expected indexes
+    expected_calls = [
+        "CREATE INDEX FOR (n:Case) ON (n.case_id)",
+        "CREATE INDEX FOR (n:DocketEntry) ON (n.entry_id)",
+        "CREATE INDEX FOR (n:Document) ON (n.doc_id)",
+        "CREATE INDEX FOR (n:Chunk) ON (n.chunk_id)",
+        "CREATE INDEX FOR (n:Party) ON (n.party_id)",
+        "CREATE INDEX FOR (n:Judge) ON (n.judge_id)",
+        "CREATE INDEX FOR (n:EventType) ON (n.event_type_id)",
+    ]
+
+    # We should have one query per index
+    assert mock_graph.query.call_count == len(expected_calls)
+
+    # Extract the queries passed to the mock
+    actual_calls = [call.args[0] for call in mock_graph.query.call_args_list]
+
+    for expected in expected_calls:
+        assert expected in actual_calls
+
+def test_init_schema_handles_existing_indexes():
+    # Arrange
+    mock_client = MagicMock()
+    mock_graph = MagicMock()
+    mock_client.select_graph.return_value = mock_graph
+
+    # Simulate the first index already existing
+    def side_effect(*args, **kwargs):
+        if "Case" in args[0]:
+            raise Exception("Index already exists")
+        return MagicMock()
+
+    mock_graph.query.side_effect = side_effect
+
+    # Act
+    init_schema(mock_client, "test_graph")
+
+    # Assert
+    # The function should swallow the exception and continue with the rest of the queries
+    assert mock_graph.query.call_count == 7 # 7 indexes total

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,7 @@ name = "backend"
 version = "0.1.0"
 source = { virtual = "backend" }
 dependencies = [
+    { name = "falkordb" },
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -59,6 +60,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "falkordb", specifier = ">=1.6.0" },
     { name = "fastapi", specifier = ">=0.136.1" },
     { name = "pydantic", specifier = ">=2.13.3" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
@@ -99,6 +101,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "falkordb"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/52/5495fcba8e21c269a605092a7c4a8b33ceecae283dbfe76fc53f7f5b50ab/falkordb-1.6.0.tar.gz", hash = "sha256:5c307d973f3fc3987a18478ebd5882f7e842d4225463a8ef5e026970ebfba8c6", size = 98157, upload-time = "2026-02-21T06:36:19.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/8b/59ec60885abd3b6b2b3a1e5917627c3cae656b4cff7f847c5217ec3dc952/falkordb-1.6.0-py3-none-any.whl", hash = "sha256:0f190e9d6104595fd51ece4f1e7b5d49d62cfee346d94151d7986a138fd90d89", size = 37378, upload-time = "2026-02-21T06:36:17.769Z" },
 ]
 
 [[package]]
@@ -325,12 +340,42 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR implements Issue #4. It adds `init_schema` logic using the `falkordb` python client, which connects to the configured falkordb instance and runs `CREATE INDEX` queries for `Case`, `DocketEntry`, `Document`, `Chunk`, `Party`, `Judge`, and `EventType` labels. It gracefully ignores exceptions for existing indexes, ensuring idempotency. It includes unit tests and an executable script in `backend/app/scripts/init_db.py`.

---
*PR created automatically by Jules for task [12357459200532122130](https://jules.google.com/task/12357459200532122130) started by @TomOrth*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated database schema initialization with index creation for optimal performance on application startup

* **Tests**
  * Added test coverage for database initialization, including error recovery scenarios

* **Chores**
  * Added required database library dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->