### PR TITLE
🧹 [code health] remove unused imports in crlca_models.py

### DIFF
--- a/backend/src/litigation_api/ingestion/crlca_models.py
+++ b/backend/src/litigation_api/ingestion/crlca_models.py
@@ -1,5 +1,5 @@
-from typing import Optional, Union, Any
-from pydantic import BaseModel, Field
+from typing import Optional, Union
+from pydantic import BaseModel
 
 class CRLCADocument(BaseModel):
     id: int


### PR DESCRIPTION
Cleaned up unused imports in `backend/src/litigation_api/ingestion/crlca_models.py` as identified by Ruff linter. Removed `Any` from `typing` and `Field` from `pydantic`. verified the changes by running `ruff check`.

---
*PR created automatically by Jules for task [8458825811492892588](https://jules.google.com/task/8458825811492892588) started by @TomOrth*