### PR TITLE
🧪 Add edge case test for missing hostname in _redact_url

### DIFF
--- a/backend/tests/test_init_db.py
+++ b/backend/tests/test_init_db.py
@@ -8,6 +8,11 @@ def test_redact_url_removes_credentials():
     assert redacted == "redis://example.com:6379/0"
 
 
+def test_redact_url_handles_missing_host():
+    assert _redact_url("/path") == "://unknown-host/path"
+    assert _redact_url("") == "://unknown-host"
+
+
 @patch("litigation_api.scripts.init_db.init_schema")
 @patch("litigation_api.scripts.init_db.FalkorDB")
 def test_main_passes_configured_graph_name(mock_falkordb, mock_init_schema):


### PR DESCRIPTION
This PR addresses a testing gap in `backend/src/litigation_api/scripts/init_db.py` by adding a test case for the `_redact_url` function when the input URL lacks a hostname.

🎯 **What:** Added `test_redact_url_handles_missing_host` to `backend/tests/test_init_db.py`.
📊 **Coverage:** The new test covers URLs with only a path (e.g., `"/path"`) and empty strings, ensuring they are redacted to `"://unknown-host/path"` and `"://unknown-host"` respectively.
✨ **Result:** Improved test coverage for a pure utility function, ensuring robust handling of malformed or unconventional URL inputs.

---
*PR created automatically by Jules for task [12050577240535868422](https://jules.google.com/task/12050577240535868422) started by @TomOrth*