### PR TITLE
Implement rules-first document classification for the v1 taxonomy

### DIFF
--- a/backend/src/litigation_api/ingestion/classification.py
+++ b/backend/src/litigation_api/ingestion/classification.py
@@ -1,0 +1,73 @@
+import re
+from typing import Optional
+import abc
+
+SUPPORTED_DOCUMENT_TYPES = {"Complaint", "Opinion/Order", "Settlement"}
+
+class ClassificationProvider(abc.ABC):
+    @abc.abstractmethod
+    def classify(self, text: str, title: Optional[str] = None, docket_title: Optional[str] = None) -> Optional[str]:
+        pass
+
+class DocumentClassifier:
+    """
+    Classifies documents into the supported v1 filing types using deterministic rules
+    with explicit fallback behavior.
+    """
+    def __init__(self, fallback_provider: Optional[ClassificationProvider] = None):
+        self.fallback_provider = fallback_provider
+        self.complaint_re = re.compile(r'\bcomplaint\b', re.IGNORECASE)
+        self.opinion_order_re = re.compile(r'\b(opinion|order|decision|ruling)\b', re.IGNORECASE)
+        self.settlement_re = re.compile(r'\b(settlement|consent decree|stipulation|agreement)\b', re.IGNORECASE)
+
+    def classify(self, document_type: Optional[str] = None, title: Optional[str] = None, docket_title: Optional[str] = None, text_content: Optional[str] = None) -> str:
+        # 1. Exact match on API provided document type
+        if document_type in SUPPORTED_DOCUMENT_TYPES:
+            return document_type
+
+        # 2. Heuristics on available fields
+        def _apply_heuristics(text: str) -> Optional[str]:
+            if self.complaint_re.search(text):
+                return "Complaint"
+            if self.settlement_re.search(text):
+                return "Settlement"
+            if self.opinion_order_re.search(text):
+                return "Opinion/Order"
+            return None
+
+        if document_type:
+            result = _apply_heuristics(document_type)
+            if result:
+                return result
+
+        if title:
+            result = _apply_heuristics(title)
+            if result:
+                return result
+
+        if docket_title:
+            result = _apply_heuristics(docket_title)
+            if result:
+                return result
+
+        # 3. Optional AI Fallback
+        if self.fallback_provider:
+            result = self.fallback_provider.classify(
+                text=text_content or "",
+                title=title,
+                docket_title=docket_title
+            )
+            if result in SUPPORTED_DOCUMENT_TYPES:
+                return result
+
+        # 4. Unknown fallback
+        return "Unknown"
+
+# Default instance to be used across the ingestion module
+default_classifier = DocumentClassifier()
+
+def classify_document(document_type: Optional[str] = None, title: Optional[str] = None, docket_title: Optional[str] = None, text_content: Optional[str] = None) -> str:
+    """
+    Convenience function that uses the default DocumentClassifier.
+    """
+    return default_classifier.classify(document_type=document_type, title=title, docket_title=docket_title, text_content=text_content)

--- a/backend/src/litigation_api/ingestion/normalization.py
+++ b/backend/src/litigation_api/ingestion/normalization.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from ..models.domain import Case, DocketEntry, Document
 from .crlca_models import CRLCACase, CRLCADocket, CRLCADocument
+from .classification import classify_document
 
 # Pre-compiled regular expressions for date parsing
 ISO_DATE_RE = re.compile(r"(\d{4})-(\d{2})-(\d{2})")
@@ -83,9 +84,12 @@ def normalize_document(source: CRLCADocument, case_id: str, entry_id: str) -> Do
     doc_id = f"crlca_doc_{source.id}"
 
     title = source.title or source.description or f"Document {source.id}"
-    doc_type = source.document_type
-    if not doc_type:
-        doc_type = "Unknown"
+    doc_type = classify_document(
+        document_type=source.document_type,
+        title=title,
+        docket_title=None, # In the CRLCA document mapping, docket_title isn't explicitly brought down here unless passed differently
+        text_content=source.description
+    )
 
     return Document(
         doc_id=doc_id,

--- a/backend/tests/ingestion/test_classification.py
+++ b/backend/tests/ingestion/test_classification.py
@@ -1,0 +1,43 @@
+from litigation_api.ingestion.classification import DocumentClassifier, ClassificationProvider, classify_document
+
+class MockFallbackProvider(ClassificationProvider):
+    def classify(self, text: str, title: str | None = None, docket_title: str | None = None) -> str | None:
+        if "secret model settlement" in (text or ""):
+            return "Settlement"
+        return None
+
+def test_exact_match():
+    classifier = DocumentClassifier()
+    assert classifier.classify(document_type="Complaint") == "Complaint"
+    assert classifier.classify(document_type="Opinion/Order") == "Opinion/Order"
+    assert classifier.classify(document_type="Settlement") == "Settlement"
+
+def test_heuristics_document_type():
+    classifier = DocumentClassifier()
+    assert classifier.classify(document_type="Amended Complaint") == "Complaint"
+    assert classifier.classify(document_type="Final Order") == "Opinion/Order"
+    assert classifier.classify(document_type="Consent Decree") == "Settlement"
+
+def test_heuristics_title():
+    classifier = DocumentClassifier()
+    assert classifier.classify(title="First Amended Complaint") == "Complaint"
+    assert classifier.classify(title="Decision on Motion to Dismiss") == "Opinion/Order"
+    assert classifier.classify(title="Stipulation of Dismissal") == "Settlement"
+
+def test_heuristics_docket_title():
+    classifier = DocumentClassifier()
+    assert classifier.classify(docket_title="Notice of Settlement") == "Settlement"
+
+def test_fallback_provider():
+    classifier = DocumentClassifier(fallback_provider=MockFallbackProvider())
+    assert classifier.classify(text_content="This is a secret model settlement.") == "Settlement"
+    assert classifier.classify(text_content="Some other random text.") == "Unknown"
+
+def test_unknown_fallback():
+    classifier = DocumentClassifier()
+    assert classifier.classify() == "Unknown"
+    assert classifier.classify(document_type="Legislative Report") == "Unknown"
+    assert classifier.classify(title="Letter to the Judge") == "Unknown"
+
+def test_default_classifier():
+    assert classify_document(document_type="Second Amended Complaint") == "Complaint"

--- a/backend/tests/ingestion/test_pipeline.py
+++ b/backend/tests/ingestion/test_pipeline.py
@@ -100,7 +100,7 @@ async def test_fetch_and_normalize_case_unsupported_document(pipeline, mock_crlc
     # Assert
     assert len(docs) == 1
     assert docs[0].doc_id == "crlca_doc_101"
-    assert docs[0].document_type == "Correspondence"
+    assert docs[0].document_type == "Unknown"
     assert docs[0].ingestion_status == "SKIPPED_UNSUPPORTED_TYPE"
 
     # Ensure no download or upload occurred

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@
 - [Ingestion Contract v1](./ingestion_contract_v1.md)
 - [Architecture Decision Records](./adr/README.md)
 - [Repo Map](./repo-map.md)
+- [Classification Fallback](./classification_fallback.md)

--- a/docs/classification_fallback.md
+++ b/docs/classification_fallback.md
@@ -1,0 +1,45 @@
+# Classification Fallback Behavior
+
+This document outlines the rules-first approach and explicit fallback behavior used by the ingestion pipeline to classify documents into the Tier 1 taxonomy.
+
+## 1. Goal
+
+The Tier 1 taxonomy specifically supports the following document types for ingestion and downstream processing (e.g., OCR, embedding, tracking):
+
+*   **Complaint**
+*   **Opinion/Order**
+*   **Settlement**
+
+All incoming documents from the Civil Rights Litigation Clearinghouse API (CRLCA) or other sources must be assigned to one of these types or gracefully marked as `"Unknown"` if unsupported.
+
+## 2. Order of Precedence
+
+The classification module evaluates a document in the following deterministic order:
+
+### 2.1. Exact Match
+If the source payload explicitly lists a `document_type` that exactly matches `Complaint`, `Opinion/Order`, or `Settlement`, that classification is used immediately.
+
+### 2.2. Deterministic Heuristics
+If there is no exact match, the system falls back to regex-based heuristics against the available fields, evaluated in this order:
+1.  `document_type`
+2.  `title`
+3.  `docket_title`
+
+Keywords evaluated (case-insensitive):
+*   **Complaint:** `\bcomplaint\b`
+*   **Opinion/Order:** `\b(opinion|order|decision|ruling)\b`
+*   **Settlement:** `\b(settlement|consent decree|stipulation|agreement)\b`
+
+### 2.3. Optional AI Fallback Interface
+An optional interface, `ClassificationProvider`, is provided to support future model-assisted classification. If injected, this provider will receive the document's text and titles to make a prediction. This is out of scope for the current Tier 1 implementation but remains an open integration point.
+
+### 2.4. Explicit Fallback ("Unknown")
+If all the steps above fail to classify the document, it is explicitly classified as `"Unknown"`.
+
+## 3. Handling "Unknown" Documents
+
+Documents classified as `"Unknown"` will not break the ingestion pipeline. According to the fallback behavior specified in the v1 Ingestion Contract:
+
+*   **Metadata Only:** The document's basic metadata is extracted and saved to the graph.
+*   **No Artifact Download:** The raw PDF file will **not** be downloaded, saving bandwidth and storage.
+*   **Status Update:** The internal representation of the document will have its `ingestion_status` marked as `SKIPPED_UNSUPPORTED_TYPE`.


### PR DESCRIPTION
Implemented the rules-first document classification module for the v1 ingestion pipeline. It maps documents to standard types (`Complaint`, `Opinion/Order`, `Settlement`) using strict exact matching followed by regex heuristics on metadata fields, and uses an explicit `Unknown` fallback. Tests and comprehensive documentation are included.

---
*PR created automatically by Jules for task [1286860520370095296](https://jules.google.com/task/1286860520370095296) started by @TomOrth*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented intelligent document classification that automatically categorizes filings into supported types (Complaint, Opinion/Order, Settlement) using deterministic rule-based matching
  * Unclassified documents are properly marked as Unknown to improve data quality

* **Improvements**
  * Enhanced document normalization to leverage the new classification system

* **Documentation**
  * Added comprehensive documentation on classification methodology and supported document types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->