### PR TITLE
fix: prioritize opinion/order over complaint in document classification

### DIFF
--- a/backend/src/litigation_api/ingestion/classification.py
+++ b/backend/src/litigation_api/ingestion/classification.py
@@ -27,12 +27,12 @@ class DocumentClassifier:
 
         # 2. Heuristics on available fields
         def _apply_heuristics(text: str) -> Optional[str]:
-            if self.complaint_re.search(text):
-                return "Complaint"
-            if self.settlement_re.search(text):
-                return "Settlement"
             if self.opinion_order_re.search(text):
                 return "Opinion/Order"
+            if self.settlement_re.search(text):
+                return "Settlement"
+            if self.complaint_re.search(text):
+                return "Complaint"
             return None
 
         if document_type:

--- a/backend/tests/ingestion/test_classification.py
+++ b/backend/tests/ingestion/test_classification.py
@@ -28,6 +28,13 @@ def test_heuristics_docket_title():
     classifier = DocumentClassifier()
     assert classifier.classify(docket_title="Notice of Settlement") == "Settlement"
 
+def test_heuristic_priority():
+    classifier = DocumentClassifier()
+    assert classifier.classify(title="Order Denying Motion to Amend Complaint") == "Opinion/Order"
+    assert classifier.classify(title="Opinion on Motion to Dismiss Complaint") == "Opinion/Order"
+    assert classifier.classify(title="Ruling on Plaintiff's Complaint") == "Opinion/Order"
+    assert classifier.classify(title="Stipulation to Dismiss Complaint") == "Settlement"
+
 def test_fallback_provider():
     classifier = DocumentClassifier(fallback_provider=MockFallbackProvider())
     assert classifier.classify(text_content="This is a secret model settlement.") == "Settlement"


### PR DESCRIPTION
Prioritizes Opinion/Order matching over Settlement and Complaint matching in the ingestion document classification heuristic to fix misclassifications. Adds unit tests for the priority order.

---
*PR created automatically by Jules for task [9562255403256928657](https://jules.google.com/task/9562255403256928657) started by @TomOrth*